### PR TITLE
Remove platform image config option

### DIFF
--- a/cli/src/core/generate/generate.go
+++ b/cli/src/core/generate/generate.go
@@ -16,7 +16,7 @@ import (
 var (
 	//go:embed template/*
 	templateFs       embed.FS
-	ErrInvalidConfig = errors.New("invalid project config, required fields are Image, ProjectName, and PlatformImage")
+	ErrInvalidConfig = errors.New("invalid project config, required fields are Image and ProjectName")
 )
 
 func createFileFromTemplate(source, destination string, generatePackageSpec core.GeneratePackageSpec) error {
@@ -68,15 +68,14 @@ func GeneratePackage(destination string, generatePackageSpec core.GeneratePackag
 }
 
 func GenerateConfigFile(config *core.Config) error {
-	if config.Image == "" || config.ProjectName == "" || config.PlatformImage == "" {
+	if config.Image == "" || config.ProjectName == "" {
 		return errors.Wrap(ErrInvalidConfig, "")
 	}
 
 	firstFields := core.Config{
-		ProjectName:   config.ProjectName,
-		Image:         config.Image,
-		PlatformImage: config.PlatformImage,
-		LogPath:       config.LogPath,
+		ProjectName: config.ProjectName,
+		Image:       config.Image,
+		LogPath:     config.LogPath,
 	}
 
 	data, err := yaml.Marshal(&firstFields)

--- a/cli/src/core/generate/generate_test.go
+++ b/cli/src/core/generate/generate_test.go
@@ -107,11 +107,10 @@ func TestGenerateConfigFile(t *testing.T) {
 		// case: assert config file created as expected
 		{
 			config: core.Config{
-				ProjectName:   "test-project",
-				Image:         "jembi/go-cli-test-image",
-				PlatformImage: "jembi/platform:latest",
-				LogPath:       "/tmp/logs",
-				Packages:      []string{"client", "dashboard-visualiser-jsreport"},
+				ProjectName: "test-project",
+				Image:       "jembi/go-cli-test-image",
+				LogPath:     "/tmp/logs",
+				Packages:    []string{"client", "dashboard-visualiser-jsreport"},
 				CustomPackages: []core.CustomPackage{
 					{
 						Id:   "disi-on-platform",
@@ -132,22 +131,13 @@ func TestGenerateConfigFile(t *testing.T) {
 		// case: assert invalid config file, missing field 'Image'
 		{
 			config: core.Config{
-				ProjectName:   "test-project",
-				PlatformImage: "jembi/platform:latest",
+				ProjectName: "test-project",
 			},
 		},
 		// case: assert invalid config file, missing field 'ProjectName'
 		{
 			config: core.Config{
-				Image:         "jembi/go-cli-test-image",
-				PlatformImage: "jembi/platform:latest",
-			},
-		},
-		// case: assert invalid config file, missing field 'PlatformImage'
-		{
-			config: core.Config{
-				Image:       "jembi/go-cli-test-image",
-				ProjectName: "test-project",
+				Image: "jembi/go-cli-test-image",
 			},
 		},
 	}

--- a/cli/src/core/parse/config_test.go
+++ b/cli/src/core/parse/config_test.go
@@ -60,10 +60,9 @@ func Test_unmarshalConfig(t *testing.T) {
 			configPath: wd + "/../../features/unit-test-configs/config-case-1.yml",
 			expectedConfig: core.Config{
 				ProjectName: "test-project",
-				Image:         "jembi/go-cli-test-image",
-				LogPath:       "/tmp/logs",
-				PlatformImage: "jembi/platform:latest",
-				Packages:      []string{"client", "dashboard-visualiser-jsreport"},
+				Image:       "jembi/go-cli-test-image",
+				LogPath:     "/tmp/logs",
+				Packages:    []string{"client", "dashboard-visualiser-jsreport"},
 				CustomPackages: []core.CustomPackage{
 					{
 						Id:   "disi-on-platform",

--- a/cli/src/core/prompt/project.go
+++ b/cli/src/core/prompt/project.go
@@ -2,11 +2,9 @@ package prompt
 
 import (
 	"cli/core"
-	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/iancoleman/strcase"
 	"github.com/luno/jettison/errors"
 	"github.com/manifoldco/promptui"
 )
@@ -37,18 +35,9 @@ func GenerateProjectPrompt() (core.Config, error) {
 
 	promptProjectImage := promptui.Prompt{
 		Label:   "What docker image would you like to use with this project",
-		Default: strcase.ToKebab(fmt.Sprintf("organisation/%v", projectName)),
-	}
-	projectImage, err := promptProjectImage.Run()
-	if err != nil {
-		return core.Config{}, errors.Wrap(err, "")
-	}
-
-	promptPlatformImage := promptui.Prompt{
-		Label:   "What Platform image is this project based on",
 		Default: "jembi/platform",
 	}
-	platformImage, err := promptPlatformImage.Run()
+	projectImage, err := promptProjectImage.Run()
 	if err != nil {
 		return core.Config{}, errors.Wrap(err, "")
 	}
@@ -75,7 +64,7 @@ func GenerateProjectPrompt() (core.Config, error) {
 	if withCustomPackages == "Yes" {
 		customPackages = append(customPackages, core.CustomPackage{
 			Id:   "<<custom-package-id>>",
-			Path: "<<custom-package-path>>",
+			Path: "<<local-path-or-github-url>>",
 		})
 	}
 
@@ -93,7 +82,7 @@ func GenerateProjectPrompt() (core.Config, error) {
 		profiles = append(profiles, core.Profile{
 			Name:     "<<profile-name>>",
 			EnvFiles: []string{"<<env-file-1>>", "<<env-file-2>>"},
-			EnvVars: []string{"<<env-var-1>>", "<<env-var-2>>"},
+			EnvVars:  []string{"<<env-var-1>>", "<<env-var-2>>"},
 			Packages: []string{"<<profile-package-id-1>>", "<<profile-package-id-2>>"},
 		})
 	}
@@ -101,7 +90,6 @@ func GenerateProjectPrompt() (core.Config, error) {
 	return core.Config{
 		Image:          projectImage,
 		ProjectName:    projectName,
-		PlatformImage:  platformImage,
 		LogPath:        logPath,
 		Packages:       []string{"<<package-id>>"},
 		CustomPackages: customPackages,

--- a/cli/src/core/types.go
+++ b/cli/src/core/types.go
@@ -17,7 +17,6 @@ type CustomPackage struct {
 type Config struct {
 	ProjectName    string          `yaml:"projectName,omitempty"`
 	Image          string          `yaml:"image,omitempty"`
-	PlatformImage  string          `yaml:"platformImage,omitempty"`
 	LogPath        string          `yaml:"logPath,omitempty"`
 	Packages       []string        `yaml:"packages,omitempty"`
 	CustomPackages []CustomPackage `yaml:"customPackages,omitempty"`

--- a/cli/src/features/unit-test-configs/config-case-1.yml
+++ b/cli/src/features/unit-test-configs/config-case-1.yml
@@ -1,7 +1,6 @@
 ---
 projectName: test-project
 image: jembi/go-cli-test-image
-platformImage: jembi/platform:latest
 logPath: /tmp/logs
 
 packages:

--- a/cli/src/features/unit-test-configs/config-case-6.yml
+++ b/cli/src/features/unit-test-configs/config-case-6.yml
@@ -1,7 +1,6 @@
 ---
 projectName: test-project
 image: jembi/go-cli-test-image
-platformImage: jembi/platform:latest
 logPath: /tmp/logs
 
 packages:


### PR DESCRIPTION
It's only needed in Ethiopia-on-platform so it's shouldn't be in the generic CLI.