### PR TITLE
feat: added multi platform build (linux/amd64, linux/arm64)

### DIFF
--- a/.github/workflows/docker push-package-base.yml
+++ b/.github/workflows/docker push-package-base.yml
@@ -29,4 +29,4 @@ jobs:
       with:
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: tryzan/package-base:${{github.ref_name}}
+        tags: openhie/package-base:${{github.ref_name}}

--- a/.github/workflows/docker push-package-base.yml
+++ b/.github/workflows/docker push-package-base.yml
@@ -9,12 +9,17 @@ jobs:
   package-base:
     runs-on: ubuntu-20.04
     steps:
-    
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -22,5 +27,6 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
+        platforms: linux/amd64,linux/arm64
         push: true
-        tags: openhie/package-base:${{github.ref_name}}
+        tags: tryzan/package-base:${{github.ref_name}}


### PR DESCRIPTION
Unable pull docker image for arm-based architectures e.g.: M1, M1Pro chips

Changed workflow to allow building amd64 & arm64 images. 

This is simalar to https://github.com/jembi/openhim-core-js/pull/1190