### PR TITLE
Fix path in runBashScript function - remove double backslash

### DIFF
--- a/instant.ts
+++ b/instant.ts
@@ -266,7 +266,7 @@ const main = async () => {
       case 'swarm':
         for (const id of chosenPackageIds) {
           setEnvVars(allPackages[id])
-          await runBashScript(`${allPackages[id].path}/`, 'swarm.sh', [
+          await runBashScript(`${allPackages[id].path}`, 'swarm.sh', [
             main.command,
             mainOptions.mode
           ])


### PR DESCRIPTION
This pull request fixes an issue in the `runBashScript` function where a double backslash was being added to the path. The fix removes the unnecessary double backslash, ensuring that the output is correct.