### PR TITLE
Update Go version to 1.23 in workflow

### DIFF
--- a/.github/workflows/release-go-cli.yaml
+++ b/.github/workflows/release-go-cli.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.23
 
     - name: Build go-cli binary releases
       run:  cd ./cli && ./buildreleases.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version used for building CLI binaries to a newer release, improving build environment compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->